### PR TITLE
Update Om to latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,12 +70,13 @@ endif(B9_UBSAN)
 
 # OMR Configuration
 
-set(OMR_COMPILER   ON  CACHE INTERNAL "Enable the Compiler.")
-set(OMR_JITBUILDER ON  CACHE INTERNAL "We use OMR's jitbuilder tool for the b9 JIT")
-set(OMR_EXAMPLE    OFF CACHE INTERNAL "Disable the GC example")
-set(OMR_OM         ON  CACHE INTERNAL "Enable OMR Om, a GC object model")
-set(OMR_GC         ON  CACHE INTERNAL "Enable the GC")
-set(OMR_FVTEST     OFF CACHE INTERNAL "Disable OMR's internal test suite, it's incompatible with b9")
+set(OMR_COMPILER           ON  CACHE INTERNAL "Enable the Compiler.")
+set(OMR_JITBUILDER         ON  CACHE INTERNAL "We use OMR's jitbuilder tool for the b9 JIT")
+set(OMR_EXAMPLE            OFF CACHE INTERNAL "Disable the GC example")
+set(OMR_OM                 ON  CACHE INTERNAL "Enable OMR Om, a GC object model")
+set(OMR_GC                 ON  CACHE INTERNAL "Enable the GC")
+set(OMR_GC_EXTENDED_API    ON  CACHE INTERNAL "Required for Om.")
+set(OMR_FVTEST             OFF CACHE INTERNAL "Disable OMR's internal test suite, it's incompatible with b9")
 set(OMR_WARNINGS_AS_ERRORS OFF CACHE INTERNAL "OMR doesn't compile cleanly on my laptop :p")
 
 # Compile a b9-js *.js to C++

--- a/b9/include/b9/VirtualMachine.hpp
+++ b/b9/include/b9/VirtualMachine.hpp
@@ -6,13 +6,12 @@
 #include <b9/compiler/Compiler.hpp>
 #include <b9/instructions.hpp>
 
-#include <OMR/Om/Context.inl.hpp>
-#include <OMR/Om/MemorySystem.hpp>
+#include <OMR/GC/StackRoot.hpp>
+#include <OMR/Om/Context.hpp>
 #include <OMR/Om/ObjectOperations.hpp>
-#include <OMR/Om/RootRef.hpp>
-#include <OMR/Om/Runtime.hpp>
 #include <OMR/Om/ShapeOperations.hpp>
 #include <OMR/Om/Value.hpp>
+#include <OMR/Runtime.hpp>
 
 #include <cstring>
 #include <map>
@@ -30,6 +29,7 @@ b9::PrimitiveFunction b9_prim_print_stack;
 namespace b9 {
 
 namespace Om = ::OMR::Om;
+namespace GC = ::OMR::GC;
 
 class Compiler;
 class ExecutionContext;
@@ -65,7 +65,7 @@ extern "C" typedef Om::RawValue (*JitFunction)(void *executionContext, ...);
 
 class VirtualMachine {
  public:
-  VirtualMachine(Om::ProcessRuntime &runtime, const Config &cfg);
+  VirtualMachine(OMR::Runtime &runtime, const Config &cfg);
 
   ~VirtualMachine() noexcept;
 
@@ -96,9 +96,9 @@ class VirtualMachine {
 
   const std::shared_ptr<const Module> &module() { return module_; }
 
-  Om::MemorySystem &memoryManager() { return memoryManager_; }
+  Om::System &memoryManager() { return memoryManager_; }
 
-  const Om::MemorySystem &memoryManager() const { return memoryManager_; }
+  const Om::System &memoryManager() const { return memoryManager_; }
 
   std::shared_ptr<Compiler> compiler() { return compiler_; }
 
@@ -109,7 +109,7 @@ class VirtualMachine {
       b9_prim_print_string, b9_prim_print_number, b9_prim_print_stack};
 
   Config cfg_;
-  Om::MemorySystem memoryManager_;
+  Om::System memoryManager_;
   std::shared_ptr<Compiler> compiler_;
   std::shared_ptr<const Module> module_;
   std::vector<JitFunction> compiledFunctions_;

--- a/b9/src/ExecutionContext.cpp
+++ b/b9/src/ExecutionContext.cpp
@@ -7,7 +7,7 @@
 
 #include <OMR/Om/ArrayOperations.hpp>
 #include <OMR/Om/ObjectOperations.hpp>
-#include <OMR/Om/RootRef.hpp>
+#include <OMR/GC/StackRoot.hpp>
 #include <OMR/Om/ShapeOperations.hpp>
 #include <OMR/Om/Value.hpp>
 
@@ -27,8 +27,8 @@ ExecutionContext::ExecutionContext(VirtualMachine &virtualMachine,
     : omContext_(virtualMachine.memoryManager()),
       virtualMachine_(&virtualMachine),
       cfg_(&cfg) {
-  omContext().userMarkingFns().push_back(
-      [this](Om::MarkingVisitor &v) { this->visit(v); });
+  omContext().gc().markingFns().push_back(
+      [this](GC::MarkingVisitor &v) { this->visit(v); });
 }
 
 void ExecutionContext::reset() {
@@ -426,7 +426,7 @@ void ExecutionContext::doPopIntoObject(Om::Id slotId) {
   if (!found) {
     static constexpr Om::SlotType type(Om::Id(0), Om::CoreType::VALUE);
 
-    Om::RootRef<Om::Object> root(*this, object);
+    GC::StackRoot<Om::Object> root(omContext().gc(), object);
     auto map = Om::transitionLayout(*this, root, {{type, slotId}});
     assert(map != nullptr);
 
@@ -446,7 +446,7 @@ void ExecutionContext::doCallIndirect() {
 
 void ExecutionContext::doSystemCollect() {
   std::cout << "SYSTEM COLLECT!!!" << std::endl;
-  OMR_GC_SystemCollect(omContext_.vmContext(), 0);
+  OMR_GC_SystemCollect(omContext().gc().vm(), 0);
 }
 
 }  // namespace b9

--- a/b9/src/VirtualMachine.cpp
+++ b/b9/src/VirtualMachine.cpp
@@ -2,10 +2,10 @@
 #include <b9/VirtualMachine.hpp>
 #include <b9/compiler/Compiler.hpp>
 
+#include <OMR/GC/StackRoot.hpp>
 #include <OMR/Om/Allocator.hpp>
 #include <OMR/Om/ArrayOperations.hpp>
 #include <OMR/Om/ObjectOperations.hpp>
-#include <OMR/Om/RootRef.hpp>
 #include <OMR/Om/ShapeOperations.hpp>
 #include <OMR/Om/Value.hpp>
 
@@ -25,7 +25,7 @@ namespace b9 {
 
 constexpr PrimitiveFunction *const VirtualMachine::primitives_[3];
 
-VirtualMachine::VirtualMachine(Om::ProcessRuntime &runtime, const Config &cfg)
+VirtualMachine::VirtualMachine(OMR::Runtime &runtime, const Config &cfg)
     : cfg_{cfg}, memoryManager_(runtime), compiler_{nullptr} {
   if (cfg_.verbose) std::cout << "VM initializing..." << std::endl;
 

--- a/b9run/main.cpp
+++ b/b9run/main.cpp
@@ -2,10 +2,9 @@
 #include <b9/compiler/Compiler.hpp>
 #include <b9/deserialize.hpp>
 
-#include <OMR/Om/Context.inl.hpp>
-#include <OMR/Om/MemorySystem.hpp>
-#include <OMR/Om/RootRef.hpp>
-#include <OMR/Om/Runtime.hpp>
+#include <OMR/GC/StackRoot.hpp>
+#include <OMR/Om/Context.hpp>
+#include <OMR/Runtime.hpp>
 
 #include <strings.h>
 #include <cstdio>
@@ -117,7 +116,7 @@ static bool parseArguments(RunConfig& cfg, const int argc, char* argv[]) {
   return true;
 }
 
-static void run(Om::ProcessRuntime& runtime, const RunConfig& cfg) {
+static void run(OMR::Runtime& runtime, const RunConfig& cfg) {
   b9::VirtualMachine vm{runtime, cfg.b9};
 
   std::ifstream file(cfg.moduleName, std::ios_base::in | std::ios_base::binary);
@@ -134,7 +133,7 @@ static void run(Om::ProcessRuntime& runtime, const RunConfig& cfg) {
 }
 
 int main(int argc, char* argv[]) {
-  Om::ProcessRuntime runtime;
+  OMR::Runtime runtime;
   RunConfig cfg;
 
   if (!parseArguments(cfg, argc, argv)) {

--- a/test/b9test.cpp
+++ b/test/b9test.cpp
@@ -12,7 +12,8 @@
 namespace b9 {
 namespace test {
 
-using namespace OMR::Om;
+namespace Om = OMR::Om;
+namespace GC = OMR::GC;
 
 // clang-format off
 const std::vector<const char*> TEST_NAMES = {
@@ -44,7 +45,7 @@ const std::vector<const char*> TEST_NAMES = {
 };
 // clang-format on
 
-Om::ProcessRuntime runtime;
+OMR::Runtime runtime;
 
 class InterpreterTest : public ::testing::Test {
  public:
@@ -141,8 +142,8 @@ TEST(MyTest, arguments) {
                                 END_SECTION};
   m->functions.push_back(b9::FunctionDef{"add_args", i, 2, 0});
   vm.load(m);
-  auto r = vm.run("add_args", {{AS_INT48, 1}, {AS_INT48, 2}});
-  EXPECT_EQ(r, Value(AS_INT48, 3));
+  auto r = vm.run("add_args", {{Om::AS_INT48, 1}, {Om::AS_INT48, 2}});
+  EXPECT_EQ(r, Om::Value(Om::AS_INT48, 3));
 }
 
 TEST(MyTest, jitSimpleProgram) {
@@ -157,7 +158,7 @@ TEST(MyTest, jitSimpleProgram) {
   vm.load(m);
   vm.generateAllCode();
   auto r = vm.run("add", {});
-  EXPECT_EQ(r, Value(AS_INT48, 0xdead));
+  EXPECT_EQ(r, Om::Value(Om::AS_INT48, 0xdead));
 }
 
 TEST(MyTest, haveAVariable) {
@@ -172,7 +173,7 @@ TEST(MyTest, haveAVariable) {
   vm.load(m);
   vm.generateAllCode();
   auto r = vm.run("add", {});
-  EXPECT_EQ(r, Value(AS_INT48, 0xdead));
+  EXPECT_EQ(r, Om::Value(Om::AS_INT48, 0xdead));
 }
 
 TEST(ObjectTest, allocateSomething) {
@@ -193,8 +194,8 @@ TEST(ObjectTest, allocateSomething) {
   m->strings.push_back("Hello, World");
   m->functions.push_back(b9::FunctionDef{"allocate_object", i, 0, 1});
   vm.load(m);
-  Value r = vm.run("allocate_object", {});
-  EXPECT_EQ(r, Value(AS_INT48, 0));
+  Om::Value r = vm.run("allocate_object", {});
+  EXPECT_EQ(r, Om::Value(Om::AS_INT48, 0));
 }
 
 }  // namespace test

--- a/test/testDisasm.cpp
+++ b/test/testDisasm.cpp
@@ -276,7 +276,7 @@ TEST(ReadBinaryTest, runValidModule) {
   serialize(buffer, *m1);
 
   auto m2 = deserialize(buffer);
-  Om::ProcessRuntime runtime;
+  OMR::Runtime runtime;
   VirtualMachine vm(runtime, {});
   vm.load(m2);
   vm.run(0, {Om::Value(Om::AS_INT48, 1), Om::Value(Om::AS_INT48, 2)});


### PR DESCRIPTION
The newest Om changes split some functionality off to OMR and the GC. The main difference is that some names have changed and moved to `OMR::GC`. For example, `Om::RootRef` is now `GC::StackRoot`, and the root list is hung off the `GC::Context`.

As well, I've stopped `using namespace Om`, so it's clear what's `OMR::GC` and what's `OMR::Om`.

Signed-off-by: Robert Young <rwy0717@gmail.com>